### PR TITLE
Enable upload to Zenodo

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -206,9 +206,9 @@ PY
                     sh 'echo "name: ${HP_VS_MP_NAME}" > ${HP_VS_MP_NAME}_log.yaml'
                     sh 'echo "min_ancestor_information_content: $RESNIK_THRESHOLD" >> ${HP_VS_MP_NAME}_log.yaml'
                     sh 'echo "versions: " >> ${HP_VS_MP_NAME}_log.yaml'
-                    sh 'echo "  hp: ${HP_VERSION}" >> ${HP_VS_HP_NAME}_log.yaml'
-                    sh 'echo "  mp: ${MP_VERSION}" >> ${HP_VS_HP_NAME}_log.yaml'
-                    sh 'echo "  phenio: ${PHENIO_VERSION}" >> ${HP_VS_HP_NAME}_log.yaml'
+                    sh 'echo "  hp: ${HP_VERSION}" >> ${HP_VS_MP_NAME}_log.yaml'
+                    sh 'echo "  mp: ${MP_VERSION}" >> ${HP_VS_MP_NAME}_log.yaml'
+                    sh 'echo "  phenio: ${PHENIO_VERSION}" >> ${HP_VS_MP_NAME}_log.yaml'
                     // sh '. venv/bin/activate && printf "%s\n" "${SHORTHIST}" >> ${HP_VS_MP_NAME}_log.yaml'
                 }
             }
@@ -235,9 +235,9 @@ PY
                     sh 'echo "name: ${HP_VS_ZP_NAME}" > ${HP_VS_ZP_NAME}_log.yaml'
                     sh 'echo "min_ancestor_information_content: $RESNIK_THRESHOLD" >> ${HP_VS_ZP_NAME}_log.yaml'
                     sh 'echo "versions: " >> ${HP_VS_ZP_NAME}_log.yaml'
-                    sh 'echo "  hp: ${HP_VERSION}" >> ${HP_VS_HP_NAME}_log.yaml'
-                    sh 'echo "  mp: ${ZP_VERSION}" >> ${HP_VS_HP_NAME}_log.yaml'
-                    sh 'echo "  phenio: ${PHENIO_VERSION}" >> ${HP_VS_HP_NAME}_log.yaml'
+                    sh 'echo "  hp: ${HP_VERSION}" >> ${HP_VS_ZP_NAME}_log.yaml'
+                    sh 'echo "  zp: ${ZP_VERSION}" >> ${HP_VS_ZP_NAME}_log.yaml'
+                    sh 'echo "  phenio: ${PHENIO_VERSION}" >> ${HP_VS_ZP_NAME}_log.yaml'
                     // sh '. venv/bin/activate && printf "%s\n" "${SHORTHIST}" >> ${HP_VS_ZP_NAME}_log.yaml'
                 }
             }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,111 @@
 # automate-pheno-comparisons
-Jenkins-based automation of phenotype semantic similarity on PHENIO with Semsimian. 
+Jenkins-based automation of phenotype semantic similarity on PHENIO with Semsimian.
+
+## Overview
+
+This repository provides two equivalent ways to run the phenotype comparison pipeline:
+
+- `Jenkinsfile`: CI pipeline that runs comparisons and publishes results to Zenodo.
+- `run_pipeline.py`: local runner intended to mirror the Jenkins behavior.
+
+Each run produces three comparison tarballs:
+
+- `HP_vs_HP_semsimian_phenio.tar.gz`
+- `HP_vs_MP_semsimian_phenio.tar.gz`
+- `HP_vs_ZP_semsimian_phenio.tar.gz`
+
+Each tarball includes the similarity TSV, a YAML log file, and the information-content file used.
 
 ## Data Releases
 
-The results of this process are available on Zenodo: https://doi.org/10.5281/zenodo.18474575
+The results of this process are available on Zenodo:
+
+- DOI: https://doi.org/10.5281/zenodo.18474575
+- Latest record example: https://zenodo.org/records/18474576
+
+## Zenodo Publishing Behavior
+
+Both the Jenkins pipeline and `run_pipeline.py` publish a new Zenodo *version* on each run:
+
+1. Create a new version draft from an existing record.
+2. Remove any files inherited from the previous version.
+3. Upload the new tarballs to the draft bucket.
+4. Publish the draft.
+
+The version name is set to the run date in `YYYY-MM-DD` format by default (for example `2025-07-24`).
+
+No credentials are stored in this repository. Zenodo credentials are provided at runtime.
+
+## Jenkins Usage
+
+Run the Jenkins pipeline with these build parameters:
+
+- `ZENODO_TOKEN` (required): Zenodo API token. This can be obtained from the "Applications" section of your Zenodo account menu.
+- `ZENODO_RECORD_ID` (required, default `18474576`): Zenodo record ID to version.
+
+The pipeline uses today’s date as the version name (UTC from the Jenkins host). You can change
+the record ID per run by overriding `ZENODO_RECORD_ID`.
+
+## Local Usage (`run_pipeline.py`)
+
+The Python script mirrors the Jenkins pipeline and supports the same Zenodo publishing flow.
+
+### Basic Run
+
+```bash
+python3 run_pipeline.py
+```
+
+### Run With Zenodo Upload
+
+```bash
+python3 run_pipeline.py \
+  --zenodo-record-id 18474576 \
+  --zenodo-token "$ZENODO_TOKEN"
+```
+
+### Select Comparisons
+
+```bash
+python3 run_pipeline.py --comparison hp-hp
+python3 run_pipeline.py --comparison hp-mp
+python3 run_pipeline.py --comparison hp-zp
+```
+
+### Custom Working Directory or PHENIO
+
+```bash
+python3 run_pipeline.py --working-dir /path/to/workdir
+python3 run_pipeline.py --custom-phenio /path/to/phenio.db
+```
+
+### Test Mode (Skip Comparisons)
+
+```bash
+python3 run_pipeline.py --test-mode
+```
+
+### Zenodo Options
+
+```bash
+python3 run_pipeline.py \
+  --zenodo-record-id 18474576 \
+  --zenodo-token "$ZENODO_TOKEN" \
+  --zenodo-version 2025-07-24 \
+  --zenodo-base-url https://zenodo.org/api
+```
+
+## Runtime Arguments (Summary)
+
+Common options for `run_pipeline.py`:
+
+- `--working-dir`: Directory for pipeline execution (default `./working`)
+- `--comparison`: `all`, `hp-hp`, `hp-mp`, or `hp-zp` (default `all`)
+- `--resnik-threshold`: Minimum ancestor information content (default `1.5`)
+- `--custom-phenio`: Path to a local PHENIO SQLite database
+- `--skip-setup`: Skip tool downloads and data fetch
+- `--test-mode`: Download data but skip comparisons
+- `--zenodo-record-id`: Zenodo record ID (required to publish)
+- `--zenodo-token`: Zenodo API token (required to publish)
+- `--zenodo-version`: Zenodo version name (default: today `YYYY-MM-DD`)
+- `--zenodo-base-url`: Zenodo API base URL (default `https://zenodo.org/api`)

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -230,7 +230,8 @@ class ZenodoClient:
             f"{self.base_url}/deposit/depositions/{record_id}/actions/newversion"
         )
         if not response or "links" not in response or "latest_draft" not in response["links"]:
-            raise RuntimeError("Zenodo API did not return a latest_draft link.")
+            raise RuntimeError(
+                "Zenodo API did not return a latest_draft link.")
 
         latest_draft_url = response["links"]["latest_draft"]
         draft = self._request("GET", latest_draft_url)
@@ -264,7 +265,8 @@ class ZenodoClient:
         if parsed.scheme != "https":
             raise ValueError(f"Unexpected Zenodo bucket URL: {bucket_url}")
 
-        target_path = parsed.path.rstrip('/') + '/' + urllib.parse.quote(file_path.name)
+        target_path = parsed.path.rstrip(
+            '/') + '/' + urllib.parse.quote(file_path.name)
         file_size = file_path.stat().st_size
 
         connection = http.client.HTTPSConnection(parsed.netloc)
@@ -608,7 +610,8 @@ class PipelineRunner:
 
         bucket_url = draft.get("links", {}).get("bucket")
         if not bucket_url:
-            raise RuntimeError("Zenodo draft does not include a bucket URL for uploads.")
+            raise RuntimeError(
+                "Zenodo draft does not include a bucket URL for uploads.")
 
         for file_path in existing_files:
             logger.info(f"Uploading {file_path.name} to Zenodo...")

--- a/run_pipeline.py
+++ b/run_pipeline.py
@@ -28,6 +28,8 @@ Examples:
 
 import argparse
 import gzip
+import http.client
+import json
 import logging
 import os
 import shutil
@@ -36,6 +38,8 @@ import sys
 import tarfile
 import threading
 import time
+import urllib.error
+import urllib.parse
 import urllib.request
 import zipfile
 from datetime import datetime
@@ -131,6 +135,7 @@ class PipelineConfig:
 
         # Date-based naming
         self.build_date = datetime.now().strftime('%Y%m%d')
+        self.release_date = datetime.now().strftime('%Y-%m-%d')
 
         # Pipeline parameters
         self.resnik_threshold = '1.5'
@@ -182,6 +187,118 @@ class PipelineConfig:
         else:
             # Use default OBO PHENIO with semsimian
             return "semsimian:sqlite:obo:phenio"
+
+
+class ZenodoClient:
+    """Minimal Zenodo API client for creating new versions and uploading files."""
+
+    def __init__(self, token: str, base_url: str = "https://zenodo.org/api"):
+        self.token = token
+        self.base_url = base_url.rstrip('/')
+
+    def _request(self, method: str, url: str, payload: Optional[Dict] = None,
+                 expect_json: bool = True) -> Optional[Dict]:
+        data = None
+        headers = {"Authorization": f"Bearer {self.token}"}
+        if payload is not None:
+            data = json.dumps(payload).encode('utf-8')
+            headers["Content-Type"] = "application/json"
+
+        request = urllib.request.Request(url, data=data,
+                                         headers=headers, method=method)
+        try:
+            with urllib.request.urlopen(request) as response:
+                body = response.read()
+        except urllib.error.HTTPError as exc:
+            error_body = exc.read().decode('utf-8', 'ignore')
+            raise RuntimeError(
+                f"Zenodo API request failed ({method} {url}): "
+                f"{exc.code} {exc.reason} {error_body}"
+            ) from exc
+
+        if not expect_json:
+            return None
+
+        if not body:
+            return {}
+        return json.loads(body.decode('utf-8'))
+
+    def create_new_version_draft(self, record_id: str) -> Dict:
+        """Create a new version draft from an existing record."""
+        response = self._request(
+            "POST",
+            f"{self.base_url}/deposit/depositions/{record_id}/actions/newversion"
+        )
+        if not response or "links" not in response or "latest_draft" not in response["links"]:
+            raise RuntimeError("Zenodo API did not return a latest_draft link.")
+
+        latest_draft_url = response["links"]["latest_draft"]
+        draft = self._request("GET", latest_draft_url)
+        if not draft or "id" not in draft:
+            raise RuntimeError("Zenodo API did not return a draft deposition.")
+        return draft
+
+    def delete_draft_files(self, draft_id: int, files: List[Dict]) -> None:
+        """Delete all files copied into the draft from the previous version."""
+        for file_info in files:
+            file_id = file_info.get("id")
+            if file_id is None:
+                continue
+            self._request(
+                "DELETE",
+                f"{self.base_url}/deposit/depositions/{draft_id}/files/{file_id}",
+                expect_json=False
+            )
+
+    def update_metadata(self, draft_id: int, metadata: Dict) -> None:
+        """Update draft metadata."""
+        self._request(
+            "PUT",
+            f"{self.base_url}/deposit/depositions/{draft_id}",
+            payload={"metadata": metadata}
+        )
+
+    def upload_file(self, bucket_url: str, file_path: Path) -> None:
+        """Stream a file upload to the Zenodo bucket URL."""
+        parsed = urllib.parse.urlparse(bucket_url)
+        if parsed.scheme != "https":
+            raise ValueError(f"Unexpected Zenodo bucket URL: {bucket_url}")
+
+        target_path = parsed.path.rstrip('/') + '/' + urllib.parse.quote(file_path.name)
+        file_size = file_path.stat().st_size
+
+        connection = http.client.HTTPSConnection(parsed.netloc)
+        try:
+            connection.putrequest("PUT", target_path)
+            connection.putheader("Authorization", f"Bearer {self.token}")
+            connection.putheader("Content-Type", "application/octet-stream")
+            connection.putheader("Content-Length", str(file_size))
+            connection.endheaders()
+
+            with file_path.open('rb') as handle:
+                while True:
+                    chunk = handle.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    connection.send(chunk)
+
+            response = connection.getresponse()
+            body = response.read().decode('utf-8', 'ignore')
+            if response.status >= 400:
+                raise RuntimeError(
+                    f"Zenodo upload failed for {file_path.name}: "
+                    f"{response.status} {response.reason} {body}"
+                )
+        finally:
+            connection.close()
+
+    def publish(self, draft_id: int) -> None:
+        """Publish the Zenodo draft deposition."""
+        self._request(
+            "POST",
+            f"{self.base_url}/deposit/depositions/{draft_id}/actions/publish",
+            expect_json=False
+        )
 
 
 class PipelineRunner:
@@ -465,6 +582,42 @@ class PipelineRunner:
 
         logger.info(f"Tarball created: {output_name}")
 
+    def upload_results_to_zenodo(self, record_id: str, token: str,
+                                 version_name: str, files: List[Path],
+                                 base_url: str = "https://zenodo.org/api") -> None:
+        """Create a new Zenodo version and upload result files."""
+        existing_files = [path for path in files if path.exists()]
+        if not existing_files:
+            logger.warning("No result files found to upload to Zenodo.")
+            return
+
+        logger.info("Creating new Zenodo version draft...")
+        client = ZenodoClient(token=token, base_url=base_url)
+        draft = client.create_new_version_draft(record_id)
+        draft_id = draft["id"]
+
+        logger.info("Clearing files inherited from previous Zenodo version...")
+        client.delete_draft_files(draft_id, draft.get("files", []))
+
+        metadata = draft.get("metadata", {})
+        if version_name:
+            metadata["version"] = version_name
+
+        logger.info(f"Updating Zenodo metadata version to {version_name}...")
+        client.update_metadata(draft_id, metadata)
+
+        bucket_url = draft.get("links", {}).get("bucket")
+        if not bucket_url:
+            raise RuntimeError("Zenodo draft does not include a bucket URL for uploads.")
+
+        for file_path in existing_files:
+            logger.info(f"Uploading {file_path.name} to Zenodo...")
+            client.upload_file(bucket_url, file_path)
+
+        logger.info("Publishing Zenodo draft...")
+        client.publish(draft_id)
+        logger.info(f"Zenodo release published (version {version_name}).")
+
     def run_similarity_comparison(self, ont1: str, ont2: str,
                                   ont1_root: str, ont2_root: str,
                                   ont1_prefix: str, ont2_prefix: str,
@@ -642,6 +795,31 @@ def main():
     )
 
     parser.add_argument(
+        '--zenodo-record-id',
+        type=str,
+        help='Zenodo record ID to version and upload results into'
+    )
+
+    parser.add_argument(
+        '--zenodo-token',
+        type=str,
+        help='Zenodo API token (pass at runtime, do not store in config)'
+    )
+
+    parser.add_argument(
+        '--zenodo-version',
+        type=str,
+        help='Version name for Zenodo release (default: today YYYY-MM-DD)'
+    )
+
+    parser.add_argument(
+        '--zenodo-base-url',
+        type=str,
+        default='https://zenodo.org/api',
+        help='Zenodo API base URL (default: https://zenodo.org/api)'
+    )
+
+    parser.add_argument(
         '--skip-setup',
         action='store_true',
         help='Skip setup stage (use if already configured)'
@@ -673,6 +851,7 @@ def main():
         custom_phenio=custom_phenio_path
     )
     config.resnik_threshold = args.resnik_threshold
+    zenodo_version = args.zenodo_version or config.release_date
 
     # Log configuration
     if config.custom_phenio:
@@ -686,6 +865,8 @@ def main():
     runner = PipelineRunner(config)
 
     try:
+        comparisons_run: List[str] = []
+
         # Run setup unless skipped
         if not args.skip_setup:
             runner.setup()
@@ -712,12 +893,41 @@ def main():
             runner.run_hp_vs_hp()
             runner.run_hp_vs_mp()
             runner.run_hp_vs_zp()
+            comparisons_run = ['hp_vs_hp', 'hp_vs_mp', 'hp_vs_zp']
         elif args.comparison == 'hp-hp':
             runner.run_hp_vs_hp()
+            comparisons_run = ['hp_vs_hp']
         elif args.comparison == 'hp-mp':
             runner.run_hp_vs_mp()
+            comparisons_run = ['hp_vs_mp']
         elif args.comparison == 'hp-zp':
             runner.run_hp_vs_zp()
+            comparisons_run = ['hp_vs_zp']
+
+        if args.test_mode:
+            logger.info("Test mode enabled; skipping Zenodo upload.")
+        elif args.zenodo_token or args.zenodo_record_id:
+            if not (args.zenodo_token and args.zenodo_record_id):
+                logger.error(
+                    "Both --zenodo-token and --zenodo-record-id are required "
+                    "to upload results to Zenodo."
+                )
+                sys.exit(1)
+
+            tarballs = []
+            for comparison in comparisons_run:
+                prefix = getattr(config, f"{comparison}_prefix")
+                tarballs.append(config.working_dir / f"{prefix}.tar.gz")
+
+            runner.upload_results_to_zenodo(
+                record_id=args.zenodo_record_id,
+                token=args.zenodo_token,
+                version_name=zenodo_version,
+                files=tarballs,
+                base_url=args.zenodo_base_url
+            )
+        else:
+            logger.info("Zenodo upload not configured; skipping.")
 
         logger.info("=" * 80)
         logger.info("SUCCESS! Pipeline completed successfully.")


### PR DESCRIPTION
This pull request significantly refactors the pipeline to publish results directly to Zenodo instead of AWS S3. It introduces a new Zenodo publishing workflow in both the Jenkins pipeline and the local Python runner, including robust handling for versioning, metadata, and uploads. The documentation is also expanded to clearly describe the new Zenodo-based process and usage instructions.

**Zenodo Integration and Publishing Workflow:**

- Jenkins pipeline (`Jenkinsfile`) is updated to:
  - Accept `ZENODO_TOKEN` and `ZENODO_RECORD_ID` as parameters for authentication and versioning.
  - Add new stages to create a Zenodo draft, clear inherited files, upload new results using `curl`, and publish the draft via the Zenodo API. [[1]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L119-R196) [[2]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L203-R289)
  - Remove all AWS S3 and CloudFront logic, fully switching to Zenodo for artifact storage. [[1]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L26-L28) [[2]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L119-R196) [[3]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L162-R221) [[4]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L203-R289)

**Python Pipeline Enhancements:**

- Adds a `ZenodoClient` class to `run_pipeline.py` for interacting with the Zenodo API, supporting draft creation, file deletion, metadata updates, file uploads (with streaming), and publishing.
- Implements a new `upload_results_to_zenodo` method in the pipeline runner to automate the full Zenodo publishing workflow, mirroring the Jenkinsfile logic.
- Adds support for version naming based on the current date, and allows customizable Zenodo API endpoints and version names.

**Documentation and Usability Improvements:**

- Expands the `README.md` with a detailed overview of the Zenodo publishing process, usage instructions for both Jenkins and local runs, and a summary of runtime arguments.

**Bug Fixes and Minor Improvements:**

- Fixes log file naming for HP vs MP and HP vs ZP comparisons to use the correct variable, preventing log overwrites. [[1]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L151-R211) [[2]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L192-R240)
- Removes unnecessary installation of `s3cmd` since S3 is no longer used.

**Summary of Most Important Changes:**

**Zenodo Publishing Integration**
- Switches all result uploads from AWS S3 to Zenodo, including authentication, artifact upload, and version publishing in both Jenkins and Python pipeline. [[1]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8R11-R20) [[2]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L119-R196) [[3]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L162-R221) [[4]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L203-R289) [[5]](diffhunk://#diff-10ecf706d7c9f7f992555dc23979f93e1fc35715189c39005255ed3169dbb250R192-R303) [[6]](diffhunk://#diff-10ecf706d7c9f7f992555dc23979f93e1fc35715189c39005255ed3169dbb250R585-R620)

**Pipeline and Codebase Refactoring**
- Adds a robust `ZenodoClient` to handle all API interactions, including streaming uploads and error handling.
- Removes all S3/CloudFront configuration and dependencies from the pipeline. [[1]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L26-L28) [[2]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L71)

**Documentation and Usability**
- Updates and expands `README.md` to document the new Zenodo workflow, usage, and runtime arguments for both Jenkins and local execution.

**Bug Fixes**
- Corrects log file naming in the comparison stages to prevent overwrites and ensure accurate logs for each comparison type. [[1]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L151-R211) [[2]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8L192-R240)

**Parameterization and Flexibility**
- Adds pipeline parameters for Zenodo credentials and record ID, and allows overriding version names and API endpoints for flexible publishing. [[1]](diffhunk://#diff-e6ffa5dc854b843b3ee3c3c28f8eae2f436c2df2b1ca299cca1fa5982e390cf8R11-R20) [[2]](diffhunk://#diff-10ecf706d7c9f7f992555dc23979f93e1fc35715189c39005255ed3169dbb250R138)

This update modernizes the artifact publishing process, improves security by removing embedded credentials, and makes the pipeline more maintainable and user-friendly.